### PR TITLE
[FEAT/#9] UrlImage 컴포넌트

### DIFF
--- a/app/src/main/java/com/example/android4/core/designsystem/component/UrlImage.kt
+++ b/app/src/main/java/com/example/android4/core/designsystem/component/UrlImage.kt
@@ -1,0 +1,56 @@
+package com.example.android4.core.designsystem.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.tooling.preview.Preview
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.example.android4.R
+
+@Composable
+fun UrlImage(
+    imageUrl: String,
+    modifier: Modifier = Modifier,
+    shape: Shape = CircleShape,
+    contentScale: ContentScale = ContentScale.Crop
+) {
+    if (LocalInspectionMode.current) {
+        Image(
+            imageVector = ImageVector.vectorResource(R.drawable.ic_launcher_background),
+            contentDescription = null,
+            contentScale = contentScale,
+            modifier = modifier.clip(shape)
+
+        )
+    } else {
+        AsyncImage(
+            model = ImageRequest.Builder(LocalContext.current)
+                .data(imageUrl)
+                .crossfade(true)
+                .build(),
+            contentDescription = null,
+            contentScale = contentScale,
+            modifier = modifier.clip(shape)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun UrlImagePreview() {
+    UrlImage(
+        imageUrl = "https://example.com/image.jpg",
+        modifier = Modifier,
+        shape = CircleShape,
+        contentScale = ContentScale.Fit
+    )
+}


### PR DESCRIPTION
## Related issue 🛠
- closed #9 

## Work Description ✏️
- 코일 컴포넌트 래핑하기

## Screenshot 📸
<img width="589" alt="image" src="https://github.com/user-attachments/assets/d2476c4e-abbe-49a1-b5b9-404aca067a18" />

## To Reviewers 📢
서버에서 받은 링크 넣으세요~