### PR TITLE
Refactor: Rename `DetailCourse` data class to `DetailCourseModel`

### DIFF
--- a/app/src/main/java/com/example/android4/presentation/detailcourse/DetailCourseViewModel.kt
+++ b/app/src/main/java/com/example/android4/presentation/detailcourse/DetailCourseViewModel.kt
@@ -1,11 +1,13 @@
 package com.example.android4.presentation.detailcourse
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.example.android4.data.dto.request.CourseLikeRequestDto
 import com.example.android4.data.service.CuratorService
-import com.example.android4.presentation.detailcourse.model.DetailCourse
 import com.example.android4.presentation.detailcourse.model.DetailCourseCardUiState
+import com.example.android4.presentation.detailcourse.model.DetailCourseModel
 import com.example.android4.presentation.detailcourse.model.DetailCourseUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import jakarta.inject.Inject
@@ -18,12 +20,15 @@ import java.time.format.DateTimeFormatter
 
 @HiltViewModel
 class DetailCourseViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val curatorService: CuratorService
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(DetailCourseUiState())
     val uiState: StateFlow<DetailCourseUiState> = _uiState.asStateFlow()
 
-    val courseId = 1L //TODO: 이전 화면에서 넘겨온 courseId 세팅
+    val course = savedStateHandle.toRoute<DetailCourse>()
+
+    val courseId = course.courseId.toLong() //TODO: 이전 화면에서 넘겨온 courseId 세팅
 
     init {
         getDetailCourse()
@@ -46,7 +51,7 @@ class DetailCourseViewModel @Inject constructor(
                     date = LocalDateTime.now().basicDateFormatter(),
                     isLike = false,
                     courseList = result.spotList.map {
-                        DetailCourse(
+                        DetailCourseModel(
                             name = it.spotName,
                             address = it.address,
                             description = it.description,

--- a/app/src/main/java/com/example/android4/presentation/detailcourse/component/RecommendCourse.kt
+++ b/app/src/main/java/com/example/android4/presentation/detailcourse/component/RecommendCourse.kt
@@ -20,12 +20,12 @@ import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.unit.dp
 import com.example.android4.core.designsystem.component.UrlImage
 import com.example.android4.core.designsystem.theme.OnnaTheme
-import com.example.android4.presentation.detailcourse.model.DetailCourse
+import com.example.android4.presentation.detailcourse.model.DetailCourseModel
 
 @Composable
 fun RecommendCourse(
     index: Int,
-    detailCourse: DetailCourse,
+    detailCourse: DetailCourseModel,
     modifier: Modifier = Modifier
 ) {
     Column(

--- a/app/src/main/java/com/example/android4/presentation/detailcourse/model/DetailCourse.kt
+++ b/app/src/main/java/com/example/android4/presentation/detailcourse/model/DetailCourse.kt
@@ -1,6 +1,6 @@
 package com.example.android4.presentation.detailcourse.model
 
-data class DetailCourse(
+data class DetailCourseModel(
     val name: String,
     val address: String,
     val description: String,

--- a/app/src/main/java/com/example/android4/presentation/detailcourse/model/DetailCourseCardUiState.kt
+++ b/app/src/main/java/com/example/android4/presentation/detailcourse/model/DetailCourseCardUiState.kt
@@ -5,7 +5,7 @@ data class DetailCourseCardUiState(
     val courseName: String = "",
     val courseDescription: String = "",
     val date: String = "",
-    val courseList: List<DetailCourse> = emptyList()
+    val courseList: List<DetailCourseModel> = emptyList()
 )
 
 data class DetailCourseUiState(


### PR DESCRIPTION
The `DetailCourse` data class has been renamed to `DetailCourseModel` for clarity and consistency.

In `DetailCourseViewModel`, `SavedStateHandle` is now used to retrieve the `courseId` from the navigation arguments. The `course` property, which holds the `DetailCourse` object passed via navigation, is used to extract the `courseId`.

## Related issue 🛠
- closed #이슈넘버

## Work Description ✏️
- 작업 내용

## Screenshot 📸
<img src="" width="360"/>

## Uncompleted Tasks 😅
- [ ] Task1

## To Reviewers 📢